### PR TITLE
build.gradle 및 docker-compose.yml 주석 추가/ 포트 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,14 +22,21 @@ repositories {
 }
 
 dependencies {
+	// spring boot & batch
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+	// lombok
+    compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	// h2
+	runtimeOnly 'com.h2database:h2'
+	// mysql
+	runtimeOnly 'com.mysql:mysql-connector-j'
+	// ### test ###
+	// spring boot & batch
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.batch:spring-batch-test'
+
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,16 +5,16 @@ services:
   mysql:
     container_name: mysql_local
     image: mysql:8.2.0
-    volumes:
-      - ./db/conf.d:/etc/mysql/conf.d # 설정 파일 - 호스트 파일
-      - ./db/initdb.d:/docker-entrypoint-initdb.d # sql 실행 파일, 컨테이너가 시작되면 sh file, sql파일이 실행된다(알파벳순으로 실행)
-    ports:  #기본 포트
-      - "3306:3306"
-    environment:
+    volumes:                                      # {호스트}:{컨테이너}
+      - ./db/conf.d:/etc/mysql/conf.d             # MySQL 설정 파일 - 호스트 파일
+      - ./db/initdb.d:/docker-entrypoint-initdb.d # sql의 create와 insert 쿼리가 들어 있음, 컨테이너가 시작되면 sh file, sql파일이 실행된다(알파벳순으로 실행)
+    ports:                                        # 외부로 노출시킬 port
+      - "3307:3306"                               # 포트 충돌로 3307으로 변경
+    environment:                                  # 환경 변수
       - MYSQL_DATABASE=pass_local
       - MYSQL_USER=pt
-      - MYSQL_PASSWORD=pt_123
-      - MYSQL_ROOT_PASSWORD=pt_123
+      - MYSQL_PASSWORD=pt_123456@
+      - MYSQL_ROOT_PASSWORD=pt_123456@
       - TZ=Asia/Seoul  #시간
     command:
         - --character-set-server=utf8mb4


### PR DESCRIPTION
- 주석으로 각 코드에 대해 설명을 추가함
- 포트 충돌로 3306에서 3307로 포트를 변경함
- 패스워드가 짧아서 영문, 특수문자, 숫자를 섞어 8자리 이상으로 변경함
( alter user '아이디'@'localhost' identified by '변경할 비번';
flush previleges;)

- 디펜던시를 실행과 테스트로 구분하여 알아보기 쉽게 하였고
- 주석으로 각 디펜던시의 목적을 추가함

This closed #9 